### PR TITLE
Remove apostrophe char causing unicode issues

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -55,7 +55,7 @@ logchange 0.5
 hwclockfile /etc/adjtime
 
 # This directive enables kernel synchronisation (every 11 minutes) of the
-# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
+# real-time clock. Note that it cannot be used along with the 'rtcfile' directive.
 
 rtcsync
 


### PR DESCRIPTION
 There is an issue  during the Configure Chrony step of provision which is from this file https://github.com/yugabyte/ansible-chrony/blob/master/tasks/configure.yml

```
TASK [ansible-chrony : Configure Chrony] ***************************************
Thursday 10 June 2021  03:23:05 +0000 (0:00:00.297)       0:00:16.526 *********
fatal: [172.151.28.93] FAILED! => {"changed": false, "failed": true, "msg": "UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1599: ordinal not in range(128)"}
        to retry, use: --limit @/opt/yugabyte/devops/yb-server-provision.retry
```

That file is including this template which has a weird apostrophe character as part of the "can't" word in the comment. That is causing the unicodedecodeerror. We need to encode that file as utf-8  - see https://github.com/ansible/ansible/issues/43667

https://github.com/yugabyte/ansible-chrony/blob/f006775f94d49995fb830c951f6732c3ce2d9f16/templates/chrony.conf.j2#L58