### PR TITLE
[PLAT-3173] Add support for multiple servers and the refclock directive for Azure VMs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ chrony_keyfile: '/etc/chrony/chrony.keys'
 chrony_pool: # 2.debian.pool.ntp.org offline iburst
 # AWS Time Sync service default
 chrony_server: '169.254.169.123 prefer iburst'
+chrony_server_list: []
 chrony_driftfile: '/var/lib/chrony/chrony.drift'
 chrony_log: 'tracking measurements statistics'
 chrony_logdir: '/var/log/chrony'
@@ -15,3 +16,4 @@ chrony_dumpdir: '/var/lib/chrony'
 chrony_initstepslew: false
 chrony_initstepslew_threshold: 30
 chrony_initstepslew_servers: '169.254.169.123'
+chrony_azure_refclock: false

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -9,6 +9,10 @@ pool {{ chrony_pool }}
 server {{ chrony_server }}
 {% endif %}
 
+{% for server in chrony_server_list %}
+server {{ server }}
+{% endfor %}
+
 keyfile {{ chrony_keyfile }}
 commandkey 1
 
@@ -59,3 +63,6 @@ hwclockfile /etc/adjtime
 
 rtcsync
 
+{% if chrony_azure_refclock %}
+refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0
+{% endif %}


### PR DESCRIPTION
Adds support for specifying Azure's timesync service and adding multiple NTP servers. This will be used when adding support for specifying NTP servers in Platform.

Tested locally.