### PR TITLE
Connect to /dev/ptp0 instead of /dev/ptp_hyperv

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -64,5 +64,5 @@ hwclockfile /etc/adjtime
 rtcsync
 
 {% if chrony_azure_refclock %}
-refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0
+refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
 {% endif %}


### PR DESCRIPTION
Older images may not have `/dev/ptp_hyperv`, but will have `/dev/ptp0`. The former is a symlink to the latter anyway, so it works. Tested by creating clusters on old and new images.