### PR TITLE
[PLAT-9736] Use ptp_hyperv as the hardware clock for Azure universes if exists

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,6 @@ chrony_initstepslew: false
 chrony_initstepslew_threshold: 30
 chrony_initstepslew_servers: '169.254.169.123'
 chrony_azure_refclock: false
+ptp_hyperv_stat:
+  stat:
+    exists: false

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,7 +1,15 @@
 ---
+- name: 'Get file stats for /dev/ptp_hyperv'
+  stat:
+    path: '/dev/ptp_hyperv'
+  register: ptp_hyperv_stat
+  when: chrony_azure_refclock
+
 - name: 'Configure Chrony'
   become: yes
   template:
     src: 'chrony.conf.j2'
     dest: "{{ chrony_conf_file }}"
+  vars:
+    ptp_hyperv_exists: "{{ ptp_hyperv_stat.stat.exists }}"
   notify: 'restart chrony'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,15 +1,14 @@
 ---
-- name: 'Get file stats for /dev/ptp_hyperv'
+- name: "Get file stats for /dev/ptp_hyperv"
   stat:
-    path: '/dev/ptp_hyperv'
+    path: "/dev/ptp_hyperv"
   register: ptp_hyperv_stat
-  when: chrony_azure_refclock
 
-- name: 'Configure Chrony'
+- name: "Configure Chrony"
   become: yes
   template:
-    src: 'chrony.conf.j2'
+    src: "chrony.conf.j2"
     dest: "{{ chrony_conf_file }}"
   vars:
     ptp_hyperv_exists: "{{ ptp_hyperv_stat.stat.exists }}"
-  notify: 'restart chrony'
+  notify: "restart chrony"

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -64,5 +64,9 @@ hwclockfile /etc/adjtime
 rtcsync
 
 {% if chrony_azure_refclock %}
+{% if ptp_hyperv_exists %}
+refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0
+{% else %}
 refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
+{% endif %}
 {% endif %}


### PR DESCRIPTION
This change will update the template for chrony such that for Azure universes, it uses /dev/ptp_hyperv if this file exists. Otherwise, it falls back to the previous behavior of using /dev/ptp0.

This behavior is advised in the Azure documentation: https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#chrony