### PR TITLE
Revert "[PLAT-13029] Adding lock timeout for ansible-sshd"

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,7 +4,6 @@
   package:
     name: 'chrony'
     state: 'present'
-    lock_timeout: 600
   tags:
     - 'chrony-install'
     - 'chrony'


### PR DESCRIPTION
lock_timeout is not present for apt module in ansible 2.8