### PR TITLE
[PLAT-14331] Adding airgap check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,5 +6,6 @@
     - 'chrony-vars'
 
 - include: "install.yml"
+  when: not (air_gap | default(false))
 - include: "configure.yml"
 - include: "service.yml"


### PR DESCRIPTION
Add airgap check for installing packages. Test by manually editing ansible-chrony locally and creating universe with airgap provider, ensure chrony install is skipped. 